### PR TITLE
Error in oauth controller when creating user

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,13 +1,13 @@
 require 'oauth2'
 class OauthsController < ApplicationController
   skip_before_filter :require_login
-  
+
   # sends the user on a trip to the provider,
   # and after authorizing there back to the callback url.
   def oauth
     login_at(params[:provider])
   end
-  
+
   def callback
     provider = params[:provider]
     begin
@@ -18,7 +18,7 @@ class OauthsController < ApplicationController
         @user = create_from(provider)
         @user.activate!
         reset_session # protect from session fixation attack
-        login_user(@user)
+        auto_login(@user)
         redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
       rescue
         redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"


### PR DESCRIPTION
I was getting an error saying that login_user was undefined. I guess it was the 'old' way of doing it. I changed it to auto_login as I couldn't find any trace of login_user in sorcery's codebase expect in the test helpers;
